### PR TITLE
Use DISS_delayed_release instead of DISS_sales_restriction for embargo date

### DIFF
--- a/pkg/proquest/etd.go
+++ b/pkg/proquest/etd.go
@@ -2,6 +2,9 @@ package proquest
 
 import (
 	"encoding/xml"
+	"log/slog"
+	"strings"
+	"time"
 )
 
 type DISSSubmission struct {
@@ -9,16 +12,15 @@ type DISSSubmission struct {
 	EmbargoCode int             `xml:"embargo_code,attr"`
 	Authorship  DISSEAuthorship `xml:"DISS_authorship"`
 	Description DISSDescription `xml:"DISS_description"`
-	Restriction DISSRestriction `xml:"DISS_restriction"`
+	Repository  DISSRepository  `xml:"DISS_repository"`
 	Content     DISSContent     `xml:"DISS_content"`
 }
 
-type DISSRestriction struct {
-	SalesRestriction DISSSalesRestriction `xml:"DISS_sales_restriction"`
-}
-
-type DISSSalesRestriction struct {
-	Remove string `xml:"remove,attr"`
+type DISSRepository struct {
+	// from ProQuest
+	// DISS_delayed_release indicates the length of embargo that the author has selected for the university repository.
+	// DISS_sales_restriction indicates the length of embargo that the author has selected for ProQuest.
+	Embargo string `xml:"DISS_delayed_release"`
 }
 
 type DISSEAuthorship struct {
@@ -111,4 +113,53 @@ type DISSAbstract struct {
 type DISSBinary struct {
 	Type     string `xml:"type,attr"`
 	FileName string `xml:",chardata"`
+}
+
+func (submission DISSSubmission) EmbargoDate() string {
+	embargoUntil := extractEmbargoDate(submission.Repository)
+	if embargoUntil == "" {
+		embargoUntil = computeEmbargoDate(submission.EmbargoCode, submission.Description.Dates.CompletionDate)
+	}
+
+	return embargoUntil
+}
+
+func computeEmbargoDate(embargoCode int, completionDate string) string {
+	if embargoCode == 0 {
+		return ""
+	}
+
+	year, err := time.Parse("2006-01", completionDate)
+	if err != nil {
+		slog.Error("Invalid completion year format", "date", completionDate, "error", err)
+		return ""
+	}
+
+	var embargoDuration time.Duration
+	switch embargoCode {
+	case 1:
+		embargoDuration = 6 * 30 * 24 * time.Hour
+	case 2:
+		embargoDuration = 12 * 30 * 24 * time.Hour
+	case 3:
+		embargoDuration = 12 * 30 * 24 * time.Hour
+	}
+
+	embargoDate := year.Add(embargoDuration)
+	return embargoDate.Format("2006-01-02") // Format as mm/dd/yyyy
+}
+
+// extractEmbargoDate extracts the embargo removal date if present in the XML
+func extractEmbargoDate(restriction DISSRepository) string {
+	if restriction.Embargo == "" {
+		return ""
+	}
+	embargo := strings.Split(restriction.Embargo, " ")[0]
+	_, err := time.Parse("2006-01-02", embargo)
+	if err != nil {
+		slog.Error("Invalid embargo removal date format", "date", restriction.Embargo, "error", err)
+		return ""
+	}
+
+	return embargo
 }

--- a/pkg/proquest/etd_test.go
+++ b/pkg/proquest/etd_test.go
@@ -1,0 +1,201 @@
+package proquest
+
+import (
+	"testing"
+)
+
+func TestEmbargoDate(t *testing.T) {
+	tests := []struct {
+		name           string
+		submission     DISSSubmission
+		expectedResult string
+		description    string
+	}{
+		{
+			name: "No embargo - code 0",
+			submission: DISSSubmission{
+				EmbargoCode: 0,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "",
+			description:    "When embargo code is 0, should return empty string",
+		},
+		{
+			name: "6 month embargo - code 1",
+			submission: DISSSubmission{
+				EmbargoCode: 1,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "2021-10-28",
+			description:    "6 month embargo should add ~180 days",
+		},
+		{
+			name: "12 month embargo - code 2",
+			submission: DISSSubmission{
+				EmbargoCode: 2,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "2022-04-26",
+			description:    "12 month embargo (code 2) should add ~360 days",
+		},
+		{
+			name: "12 month embargo - code 3",
+			submission: DISSSubmission{
+				EmbargoCode: 3,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "2022-04-26",
+			description:    "12 month embargo (code 3) should add ~360 days",
+		},
+		{
+			name: "Repository embargo date takes precedence",
+			submission: DISSSubmission{
+				EmbargoCode: 2,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "2023-12-25 some additional text",
+				},
+			},
+			expectedResult: "2023-12-25",
+			description:    "Repository embargo date should override embargo code calculation",
+		},
+		{
+			name: "Repository embargo date only (no extra text)",
+			submission: DISSSubmission{
+				EmbargoCode: 1,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "2024-01-15",
+				},
+			},
+			expectedResult: "2024-01-15",
+			description:    "Repository embargo date without additional text",
+		},
+		{
+			name: "Invalid completion date format",
+			submission: DISSSubmission{
+				EmbargoCode: 1,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "invalid-date",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "",
+			description:    "Invalid completion date should return empty string",
+		},
+		{
+			name: "Invalid repository embargo date format",
+			submission: DISSSubmission{
+				EmbargoCode: 1,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "not-a-date some text",
+				},
+			},
+			expectedResult: "2021-10-28",
+			description:    "Invalid repository embargo date should fall back to embargo code",
+		},
+		{
+			name: "Unknown embargo code",
+			submission: DISSSubmission{
+				EmbargoCode: 99, // Unknown code
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2021-05",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "2021-05-01",
+			description:    "Unknown embargo code should add no time",
+		},
+		{
+			name: "Different completion year",
+			submission: DISSSubmission{
+				EmbargoCode: 2,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "2020-12",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "2021-11-26",
+			description:    "Should work with different completion years",
+		},
+		{
+			name: "Empty completion date",
+			submission: DISSSubmission{
+				EmbargoCode: 1,
+				Description: DISSDescription{
+					Dates: DISSDates{
+						CompletionDate: "",
+					},
+				},
+				Repository: DISSRepository{
+					Embargo: "",
+				},
+			},
+			expectedResult: "",
+			description:    "Empty completion date should return empty string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.submission.EmbargoDate()
+			if result != tt.expectedResult {
+				t.Errorf("EmbargoDate() = %v, want %v\nDescription: %s",
+					result, tt.expectedResult, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
From ProQuest support

> **DISS_delayed_release** indicates the length of embargo that the author has selected for the university repository.
**DISS_sales_restriction** indicates the length of embargo that the author has selected for ProQuest.